### PR TITLE
Use true division in new-style formatter to allow float specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Formatting is easy:
 ```python
 >>> size = 1234567 * byte
 >>> "In megabytes, we have {0:MB}".format(size)
-'In megabytes, we have 1'
+'In megabytes, we have 1.234567'
 
 >>> "We have {0:MB!}".format(size) # include unit in output
-'We have 1MB'
+'We have 1.234567MB'
 
 ```
 

--- a/capacity/capacity.py
+++ b/capacity/capacity.py
@@ -214,7 +214,7 @@ class Capacity(object):
                     break
             else:
                 raise ValueError("Unknown specifier: {0}".format(specifier))
-        value = self // unit
+        value = self / unit
         if include_unit:
             value = "{0}{1}".format(value, unit_name)
         return formatter, value

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -76,21 +76,24 @@ def test_equality_to_zero():
 def test_new_style_formatting():
     assert "{0}".format(3 * GiB) == str(3 * GiB)
     assert "{0!r}".format(3 * GiB) == repr(3 * GiB)
-    assert "{0:GiB}".format(3 * GiB) == "3"
+    assert "{0:GiB}".format(3 * GiB) == "3.0"
     with pytest.raises(ValueError):
         assert "{0:kjdkj}".format(3 * GiB)
-    assert u"{0:byte}".format(100 * byte) == u"100"
+    assert u"{0:byte}".format(100 * byte) == u"100.0"
 
 
 def test_new_style_with_specifiers():
-    assert "{0:<5MiB}".format(MiB) == "1    "
-    assert "{0:>5MiB}".format(MiB) == "    1"
-    assert "{0:^5MiB}".format(MiB) == "  1  "
-    assert "{0:05MiB}".format(MiB) == "00001"
+    assert "{0:<5MiB}".format(MiB) == "1.0  "
+    assert "{0:>5MiB}".format(MiB) == "  1.0"
+    assert "{0:^5MiB}".format(MiB) == " 1.0 "
+    assert "{0:05MiB}".format(MiB) == "001.0"
+    assert "{0:gGiB}".format(3 * GiB) == "3"
+    assert "{0:.2fGiB}".format(3 * GiB) == "3.00"
+    assert "{0:+.2fGiB}".format(3 * GiB) == "+3.00"
 
 
 def test_new_style_with_unit():
-    assert "{0:<5MiB!}".format(MiB) == "1MiB "
+    assert "{0:<10MiB!}".format(MiB) == "1.0MiB    "
 
 
 def test_simple_textual_representation():


### PR DESCRIPTION
The new-style formatter uses floor division instead of true division, meaning presentation types for floating point and decimal values (`eEfFgG`) and float specifiers like "precisions" do not work. This change fixes issue #9 and allows writing code like this:

```python
>>> "{:.02fMiB}".format(6 * capacity.MB)
'5.72'
```